### PR TITLE
Use clang-cl build system, lld-link and make a windows build script

### DIFF
--- a/BUILD.cmd
+++ b/BUILD.cmd
@@ -1,0 +1,2 @@
+clang-cl -I"C:\src\vcpkg\installed\x64-windows-static\include" /Os -c expat_xml.cc /Foexpat_xml.obj
+lld-link /OUT:expat_xml-clang.exe expat_xml.obj /LIBPATH:"C:\src\vcpkg\installed\x64-windows-static\lib" libexpatmd.lib


### PR DESCRIPTION
Since we got rid of MinGW/GCC, we now switched to MSVC For quality development